### PR TITLE
improve bit timing for 19200 bl protocol

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -228,7 +228,7 @@ static char checkCrc(uint8_t* pBuff, uint16_t length)
 
 static void setReceive()
 {
-    gpio_mode_set_input(input_pin, GPIO_PULL_NONE);
+    gpio_mode_set_input(input_pin, GPIO_PULL_UP);
     received = 0;
 }
 


### PR DESCRIPTION
this fixes the bit timing to be more robust

The first issue was that serialWriteChar() was only 9 bits long, whereas a byte is 10 bits (including stop bit). It worked with 9 bits as a pullup on the other end (on the flight controller) finished off the byte, but that is susceptible to noise as a pullup isn't as strong as a GPIO write. That meant that functions like send_BAD_ACK() which only send one byte relied on the pullup to get the byte completely out. Note that it worked for sendString() as that added an extra bit time for the stop bit.

The next problem is that serialreadChar() didn't reset the timer, so it's timeout handling wasn't consistent depending on where it was called from (when the last timer reset happened). serialreadChar() also didn't check the mid-point of the start bit and didn't check the stop bit at all. This made it more likely it would see noise as a valid byte.

serialreadChar() also should return bool so that when there is a bad start bit or stop bit the command can be abandoned. The CRC usually caught the error, but we may as well use the extra bits to make it more robust.

finally debugging stats support is added to help debug the bit timing