### PR TITLE
enable GPIOB periph clock on g431 and l431

### DIFF
--- a/Mcu/g431/Inc/blutil.h
+++ b/Mcu/g431/Inc/blutil.h
@@ -134,6 +134,7 @@ static inline void bl_gpio_init(void)
     LL_GPIO_InitTypeDef GPIO_InitStruct = {0};
 
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOB);
 
     GPIO_InitStruct.Pin = input_pin;
     GPIO_InitStruct.Mode = LL_GPIO_MODE_OUTPUT;

--- a/Mcu/l431/Inc/blutil.h
+++ b/Mcu/l431/Inc/blutil.h
@@ -131,6 +131,7 @@ static inline void bl_clock_config(void)
 static inline void bl_gpio_init(void)
 {
     LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOA);
+    LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_GPIOB);
     LL_GPIO_ResetOutputPin(input_port, input_pin);
 }
 


### PR DESCRIPTION
fixes https://github.com/am32-firmware/AM32-bootloader/issues/9

