### PR TITLE
added bootloader update firmware

### DIFF
--- a/.github/workflows/CI_build_updaters.yml
+++ b/.github/workflows/CI_build_updaters.yml
@@ -14,10 +14,18 @@ jobs:
           make arm_sdk_install
           make updaters -j8
 
-      - name: Archive build
+      - name: Archive build hex
         uses: actions/upload-artifact@v3
         with:
-          name: AM32-bootloader-updaters
+          name: AM32-bootloader-updaters-hex
           path: |
             obj/*_BL_UPDATER_*.hex
+          retention-days: 7
+
+      - name: Archive build amj
+        uses: actions/upload-artifact@v3
+        with:
+          name: AM32-bootloader-updaters-amj
+          path: |
+            obj/*_BL_UPDATER_*.amj
           retention-days: 7

--- a/.github/workflows/CI_build_updaters.yml
+++ b/.github/workflows/CI_build_updaters.yml
@@ -1,0 +1,23 @@
+name: CI Build Bootloader updaters Linux
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: 'ubuntu-latest'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build CI Bootloader Updaters
+        run: |
+          make arm_sdk_install
+          make updaters -j8
+
+      - name: Archive build
+        uses: actions/upload-artifact@v3
+        with:
+          name: AM32-bootloader-updaters
+          path: |
+            obj/*_BL_UPDATER_*.hex
+          retention-days: 7

--- a/Mcu/l431/Inc/blutil.h
+++ b/Mcu/l431/Inc/blutil.h
@@ -148,6 +148,7 @@ void Error_Handler()
     while (1) {}
 }
 
+#ifdef FIRMWARE_RELATIVE_START
 /*
   jump from the bootloader to the application code
  */
@@ -170,6 +171,7 @@ static inline void jump_to_application(void)
         "bx	%1	\n"
 	: : "r"(stack_top), "r"(JumpAddress) :);
 }
+#endif // FIRMWARE_RELATIVE_START
 
 void SystemInit(void)
 {

--- a/Mcu/v203/Link_BLU.ld
+++ b/Mcu/v203/Link_BLU.ld
@@ -1,0 +1,138 @@
+/*
+        linker script for CH32V203 bootloader updater
+*/
+ENTRY( _start )
+
+__stack_size = 2048;
+
+PROVIDE( _stack_size = __stack_size );
+
+MEMORY
+{
+        /*
+        note that flash for eeprom is at 0x08000000, but we flash at 0x00000000 for link
+        */
+        FLASH (rx) : ORIGIN = 0x00001000, LENGTH = 8K
+	RAM (xrw) : ORIGIN = 0x20000000, LENGTH = 20K
+}
+
+
+SECTIONS
+{
+
+	.init :
+	{
+		_sinit = .;
+		. = ALIGN(4);
+		KEEP(*(SORT_NONE(.init)))
+		. = ALIGN(4);
+		_einit = .;
+	} >FLASH AT>FLASH
+
+        .vector :
+        {
+              *(.vector);
+              . = ALIGN(64);
+        } >FLASH AT>FLASH
+
+	.text :
+	{
+		. = ALIGN(4);
+		*(.text)
+		*(.text.*)
+		*(.rodata)
+		*(.rodata*)
+		*(.gnu.linkonce.t.*)
+		. = ALIGN(4);
+	} >FLASH AT>FLASH 
+
+	.fini :
+	{
+		KEEP(*(SORT_NONE(.fini)))
+		. = ALIGN(4);
+	} >FLASH AT>FLASH
+
+	PROVIDE( _etext = . );
+	PROVIDE( _eitcm = . );	
+
+	.preinit_array  :
+	{
+	  PROVIDE_HIDDEN (__preinit_array_start = .);
+	  KEEP (*(.preinit_array))
+	  PROVIDE_HIDDEN (__preinit_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.init_array     :
+	{
+	  PROVIDE_HIDDEN (__init_array_start = .);
+	  KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+	  KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+	  PROVIDE_HIDDEN (__init_array_end = .);
+	} >FLASH AT>FLASH 
+	
+	.fini_array     :
+	{
+	  PROVIDE_HIDDEN (__fini_array_start = .);
+	  KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+	  KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+	  PROVIDE_HIDDEN (__fini_array_end = .);
+	} >FLASH AT>FLASH 
+	
+        .dalign :
+	{
+		. = ALIGN(4);
+		PROVIDE(_data_vma = .);
+	} >RAM AT>FLASH	
+
+	.dlalign :
+	{
+		. = ALIGN(4); 
+		PROVIDE(_data_lma = .);
+	} >FLASH AT>FLASH
+
+	.data :
+	{
+    	*(.gnu.linkonce.r.*)
+    	*(.data .data.*)
+    	*(.gnu.linkonce.d.*)
+		. = ALIGN(8);
+    	PROVIDE( __global_pointer$ = . + 0x800 );
+    	*(.sdata .sdata.*)
+		*(.sdata2.*)
+    	*(.gnu.linkonce.s.*)
+    	. = ALIGN(8);
+    	*(.srodata.cst16)
+    	*(.srodata.cst8)
+    	*(.srodata.cst4)
+    	*(.srodata.cst2)
+    	*(.srodata .srodata.*)
+    	. = ALIGN(4);
+		PROVIDE( _edata = .);
+	} >RAM AT>FLASH
+
+	.bss :
+	{
+		. = ALIGN(4);
+		PROVIDE( _sbss = .);
+  	    *(.sbss*)
+        *(.gnu.linkonce.sb.*)
+		*(.bss*)
+     	*(.gnu.linkonce.b.*)		
+		*(COMMON*)
+		. = ALIGN(4);
+		PROVIDE( _ebss = .);
+	} >RAM AT>FLASH
+
+	PROVIDE( _end = _ebss);
+	PROVIDE( end = . );
+
+    .stack ORIGIN(RAM) + LENGTH(RAM) - __stack_size :
+    {
+        PROVIDE( _heap_end = . );   
+        . = ALIGN(4);
+        PROVIDE(_susrstack = . );
+        . = . + __stack_size;
+        PROVIDE( _eusrstack = .);
+    } >RAM 
+
+}

--- a/bl_update/ldscript_bl.ld
+++ b/bl_update/ldscript_bl.ld
@@ -1,0 +1,135 @@
+/*
+       linker file for AM32 bootloader updater
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+_estack = 0x20001000;    /* end of RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+FLASH (rx)      : ORIGIN = 0x08001000, LENGTH = 8K
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 4K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/bl_update/main.c
+++ b/bl_update/main.c
@@ -1,0 +1,98 @@
+/*
+  bootloader update firmware
+
+  this updates the bootloader on an AM32 ESC. It assumes the
+  bootloader flash sectors are unlocked
+ */
+#include <main.h>
+#include <stdio.h>
+
+#include <version.h>
+#include <stdbool.h>
+#include "eeprom.h"
+
+#pragma GCC optimize("O0")
+
+#include <string.h>
+
+#define GPIO_PORT_TYPE typeof(GPIOA)
+
+// dummy pin and port so we can re-use blutil.h
+static GPIO_PORT_TYPE input_port;
+static uint32_t input_pin;
+#define FIRMWARE_RELATIVE_START 0x1000
+
+#define MCU_FLASH_START 0x08000000
+
+/*
+  use stringize to construct an include of the right bootloader header
+ */
+#define bl_header BL_HEADER_FILE
+#define xstr(x) #x
+#define str(x) xstr(x)
+#include str(bl_header)
+
+#include <blutil.h>
+
+static void delayMicroseconds(uint32_t micros)
+{
+    while (micros > 0) {
+        uint32_t us = micros>10000?10000:micros;
+        bl_timer_reset();
+        while (bl_timer_us() < us) ;
+        micros -= us;
+    }
+}
+
+static void flash_bootloader(void)
+{
+    uint32_t length = sizeof(bl_image);
+    uint32_t address = MCU_FLASH_START;
+    const uint8_t *bl = &bl_image[0];
+
+    while (length > 0) {
+        uint32_t chunk = 256;
+        if (chunk > length) {
+            chunk = length;
+        }
+        // loop until the flash succeeds. We expect it to pass
+        // first time, so this is paranoia
+        while (!save_flash_nolib(bl, chunk, address)) {
+        }
+        length -= chunk;
+        address += chunk;
+        bl += chunk;
+    }
+}
+
+int main(void)
+{
+    bl_clock_config();
+    bl_timer_init();
+
+    // give 1.5s for debugger to attach
+    delayMicroseconds(1500000);
+
+    // don't risk erasing the bootloader if it already matches
+    if (memcmp((const void*)MCU_FLASH_START, bl_image, sizeof(bl_image)) != 0) {
+        flash_bootloader();
+    }
+
+    /*
+      wipe eeprom header to ensure we don't boot this firmware
+      again. We wipe all 3 possible eeprom addresses for 32k, 64k and
+      128k boards
+
+      On boards with 32k of flash the 2nd two will fail. On boards
+      with 64k flash the last one will fail
+    */
+    const uint8_t zeros[8] = {0};
+    save_flash_nolib(zeros, sizeof(zeros), MCU_FLASH_START+0x7c00);
+    save_flash_nolib(zeros, sizeof(zeros), MCU_FLASH_START+0xf800);
+    save_flash_nolib(zeros, sizeof(zeros), MCU_FLASH_START+0x1f800);
+
+    // if we got here then reboot
+    NVIC_SystemReset();
+
+    return 0;
+}

--- a/bl_update/make_amj.py
+++ b/bl_update/make_amj.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+'''
+Create an AM32 amj file from a *.hex firmware firmware for bootloader update image
+'''
+
+import argparse
+import json
+import base64
+import os
+import sys
+
+parser = argparse.ArgumentParser(description='make_amj')
+
+parser.add_argument('hex')
+parser.add_argument('amj')
+parser.add_argument("--type", default="bl_update")
+parser.add_argument("--githash", default="unknown")
+
+args = parser.parse_args()
+
+img = open(args.hex, 'rb').read()
+
+default_flash_sizes = {
+    "F031" : 32,
+    "F051" : 32,
+    "G071" : 128,
+    "E230" : 32,
+    "F415" : 32,
+    "F421" : 32,
+    "L431" : 64,
+    "G431" : 64,
+    "V203" : 64,
+}
+
+bname = os.path.basename(args.hex)
+a = bname.split("_")
+if a[0] != 'AM32' or a[2] != 'BL' or a[3] != "UPDATER" or not a[-1].endswith(".hex"):
+    print("Bad hex file name")
+    sys.exit(1)
+MCU = a[1]
+PIN = a[4]
+VER = a[-1][:-4]
+
+if len(a) == 6:
+    flash_size = "%uK" % default_flash_sizes[MCU]
+elif len(a) == 7:
+    flash_size = a[-2]
+else:
+    print("Bad hex file name2")
+    sys.exit(1)
+if not MCU in 'E230 F031 F051 F415 F415_128K F421 G071 G071_64K L431 L431_128K G431 V203'.split():
+    print(f"Bad MCU {MCU}")
+    sys.exit(1)
+
+d = {
+    "type": args.type,
+    "mcuType": MCU,
+    "pin": PIN,
+    "githash": args.githash,
+    "version": VER,
+    "flashSize": flash_size,
+    "hex": base64.b64encode(img).decode('utf-8'),
+}
+
+f = open(args.amj, "w")
+f.write(json.dumps(d, indent=4))
+f.close()

--- a/bl_update/make_binheader.py
+++ b/bl_update/make_binheader.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+'''
+convert a binary file to a C header
+'''
+
+import sys
+
+def binary_to_c_header(binary_filename, header_filename, array_name="bl_image", pad=8):
+    """
+    Reads a binary file and writes a C header file with a constant uint8_t array.
+
+    :param binary_filename: The path to the binary file to read.
+    :param header_filename: The path to the C header file to write.
+    :param array_name: The name of the array variable in the generated C code.
+    """
+    try:
+        # Read the binary file
+        with open(binary_filename, 'rb') as bin_file:
+            binary_data = bin_file.read()
+
+        # possibly pad with zeros
+        if len(binary_data) % pad != 0:
+            pad_len = pad - len(binary_data) % pad
+            pad_bytes = bytes([0]*pad_len)
+            binary_data += pad_bytes
+
+        # Open the header file for writing
+        with open(header_filename, 'w') as header_file:
+            # Write header guard
+            guard_macro = '{}_H'.format(array_name.upper())
+            header_file.write(f'// generated from {binary_filename}\n')
+            header_file.write('#pragma once\n')
+            header_file.write('#include <stdint.h>\n\n')
+
+            # Write the array declaration
+            header_file.write('static const uint8_t {}[] = {{\n'.format(array_name))
+
+            # Convert binary data to a list of hex strings
+            hex_values = ['0x{:02X}'.format(b) for b in binary_data]
+
+            # Define how many values to include per line
+            line_length = 16  # Adjust this for more or fewer per line
+
+            # Write the hex values into the array
+            for i in range(0, len(hex_values), line_length):
+                line = ', '.join(hex_values[i:i+line_length])
+                if i + line_length >= len(hex_values):
+                    # Last line without trailing comma
+                    header_file.write('    {}\n'.format(line))
+                else:
+                    header_file.write('    {},\n'.format(line))
+
+            header_file.write('};\n\n')
+
+        print("Wrote {}".format(header_filename))
+
+    except IOError as e:
+        print("An I/O error occurred: {}".format(e))
+        sys.exit(1)
+
+from argparse import ArgumentParser
+parser = ArgumentParser(description=__doc__)
+
+parser.add_argument("binfile", help="binary input file")
+parser.add_argument("header", help="C header output file")
+args = parser.parse_args()
+
+binary_to_c_header(args.binfile, args.header)
+sys.exit(0)

--- a/tools/gdb-openocd.init
+++ b/tools/gdb-openocd.init
@@ -1,0 +1,4 @@
+target extended-remote :3333
+set mem inaccessible-by-default off
+set print pretty
+set confirm off

--- a/v203makefile.mk
+++ b/v203makefile.mk
@@ -5,6 +5,7 @@ RISCV_SDK_PREFIX := tools/$(OSDIR)/riscv-embedded-gcc/bin/riscv-none-embed-
 $(MCU)_CC := $(RISCV_SDK_PREFIX)gcc
 $(MCU)_OBJCOPY := $(RISCV_SDK_PREFIX)objcopy
 $(MCU)_LDSCRIPT := Mcu/v203/Link.ld
+$(MCU)_LDSCRIPT_BLU := Mcu/v203/Link_BLU.ld
 
 MCU_LC := $(call lc,$(MCU))
 


### PR DESCRIPTION
this adds an automatic build of a bootloader update firmware for all bootloaders

For example, it builds AM32_E230_BL_UPDATER_PB4_V12.hex which corresponds to AM32_E230_BOOTLOADER_PB4_V12.hex

when you load this firmware it pauses for 1.5s then replaces the bootloader with the new bootloader. If power is interrupted during this process then the ESC can only be recovered with a debug adapter.

If the currently installed bootloader is the same as the one embedded in the updater then the erase of the current bootloader is skipped

Once the new bootloader is written then the 3 possible eeprom locations are invalidated by writing 8 bytes of zero. This will prevent the updater firmware from running again

update: now builds an 'amj' file, AM32 json, as per @freasy idea
![image](https://github.com/user-attachments/assets/7dc0a00d-19bd-4e8a-a377-c2baea9a8c04)

