### PR TITLE
Remove PULL UP segment from signal pin check

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -742,18 +742,6 @@ static void checkForSignal()
 #endif
     }
 
-    gpio_mode_set_input(input_pin, GPIO_PULL_UP);
-	
-    delayMicroseconds(500);
-
-    for (int i = 0 ; i < 500; i++) {
-	if( !(gpio_read(input_pin))){
-	    low_pin_count++;
-	}else{
-
-	}
-	delayMicroseconds(10);
-    }
     if (low_pin_count == 0) {
 	return;           // all high while pin is pulled low, bootloader signal
     }

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -723,7 +723,7 @@ static void checkForSignal()
     gpio_mode_set_input(input_pin, GPIO_PULL_DOWN);
 	
     delayMicroseconds(500);
-    if(!gpio_read(input_pin)){
+    if(gpio_read(input_pin)){
     delayMicroseconds(21000); // wait more than one PWM pulse just in case signal source is pulled high
 	}
     for(int i = 0 ; i < 500; i ++){

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -723,7 +723,9 @@ static void checkForSignal()
     gpio_mode_set_input(input_pin, GPIO_PULL_DOWN);
 	
     delayMicroseconds(500);
-
+    if(!gpio_read(input_pin)){
+    delayMicroseconds(21000); // wait more than one PWM pulse just in case signal source is pulled high
+	}
     for(int i = 0 ; i < 500; i ++){
 	if(!gpio_read(input_pin)){
 	    low_pin_count++;


### PR DESCRIPTION
Checking for no instance of low while PULL UP will always be true.

I do not yet know of a reason to check while PULL UP. 

