### PR TITLE
DroneCAN: fixed init of backup registers

### DIFF
--- a/bootloader/DroneCAN/sys_can_at32.c
+++ b/bootloader/DroneCAN/sys_can_at32.c
@@ -235,14 +235,27 @@ void CAN1_SE_IRQHandler(void)
   }
 }
 
+static void ertc_init(void)
+{
+    static bool done_init;
+    if (done_init) {
+        return;
+    }
+    done_init = true;
+    crm_periph_clock_enable(CRM_PWC_PERIPH_CLOCK, TRUE);
+    pwc_battery_powered_domain_access(TRUE);
+}
+
 uint32_t get_rtc_backup_register(uint8_t idx)
 {
-    return ertc_bpr_data_read(idx);
+    ertc_init();
+    return ertc_bpr_data_read((ertc_dt_type)idx);
 }
 
 void set_rtc_backup_register(uint8_t idx, uint32_t value)
 {
-    ertc_bpr_data_write(idx, value);
+    ertc_init();
+    ertc_bpr_data_write((ertc_dt_type)idx, value);
 }
 
 #endif // DRONECAN_SUPPORT && defined(ARTERY)

--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -843,14 +843,21 @@ static void test_string(void)
 /*
   test operation of backup domain registers
  */
-volatile uint32_t bkup_value;
+volatile struct {
+    uint32_t value;
+    uint32_t fail;
+} bkup;
+
 static void test_rtc_backup(void)
 {
-    uint32_t v = 0;
+    const uint8_t idx = 1;
     while (true) {
-        bkup_value++;
-        set_rtc_backup_register(0, bkup_value);
-        bkup_value = get_rtc_backup_register(0);
+        bkup.value++;
+        set_rtc_backup_register(idx, bkup.value);
+        const uint32_t bkup_value2 = get_rtc_backup_register(idx);
+        if (bkup_value2 != bkup.value) {
+            bkup.fail++;
+        }
         delayMicroseconds(1000);
     }
 }


### PR DESCRIPTION
ensures backup registers are available for bootloader fw update detection on F415