### PR TITLE
remove update eeprom

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -50,11 +50,6 @@
 */
 #define CHECK_EEPROM_BEFORE_JUMP 1
 
-/*
-  should we update the bootloader version in eeprom?
- */
-#define UPDATE_EEPROM_ENABLE 1
-
 #include <string.h>
 
 #ifndef MCU_FLASH_START


### PR DESCRIPTION
Can corrupt the memory if power is not stable on boot and creates issues when updating to a different settings area size.