### PR TITLE
Better treatment of invalid commands --> decreasing risk of getting stuck in the bootloader

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -333,6 +333,7 @@ static void send_ACK()
     setTransmit();
     serialwriteChar(0x30);             // good ack!
     setReceive();
+    invalid_command = 0;
 }
 
 static void send_BAD_ACK()
@@ -340,6 +341,7 @@ static void send_BAD_ACK()
     setTransmit();
     serialwriteChar(0xC1);                // bad command message.
     setReceive();
+    invalid_command++;
 }
 
 static void send_BAD_CRC_ACK()
@@ -347,6 +349,7 @@ static void send_BAD_CRC_ACK()
     setTransmit();
     serialwriteChar(0xC2);                // bad command message.
     setReceive();
+    invalid_command++;  
 }
 
 static void sendDeviceInfo()
@@ -453,7 +456,6 @@ static void decodeInput()
 	len = 4;  // package without 2 byte crc
 	if (!checkCrc((uint8_t*)rxBuffer, len)) {
 	    send_BAD_CRC_ACK();
-
 	    return;
 	}
 


### PR DESCRIPTION
Especially when using DShot bidir I found the following scenario happening sometimes:

- Pulling the signal line high (due to passthrough) --> ESC jumps to bootloader
- Reading and changing settings works fine
- switching to "normal" operation with the flight controller sending DSHot commands --> **ESC is stuck**

The bootloaders sometimes picks up DShot Bidir commands up as commands 0xFF ("CMD_SET_ADDRESS"). With invalid CRC of course. But nevertheless invalid command is never increased (since 0xFF is a valid command) and the ESC is stuck in the bootloader.

Solution:
So when we increase invalid_command whenevver we have bad CRC or unknown commands, we reduce the risk of being stuck in the bootloader and waiting for commands. As soon as we receive a valid command we set invalid_command to 0.