### PR TITLE
DroneCAN: auto-set defaults on empty eeprom

### DIFF
--- a/bootloader/DroneCAN/DroneCAN.c
+++ b/bootloader/DroneCAN/DroneCAN.c
@@ -880,6 +880,15 @@ bool DroneCAN_boot_ok(void)
 
   node_status.vendor_specific_status_code = CHECK_FW_OK;
 
+  const uint8_t eeprom_magic = *(uint8_t*)(EEPROM_START_ADD);
+  if (eeprom_magic == 0 || eeprom_magic == 0xff) {
+      can_print("resetting to defaults");
+      save_flash_nolib(default_settings, sizeof(default_settings), EEPROM_START_ADD);
+  }
+  if (eeprom_magic != 0x01) {
+    set_reason(FAIL_REASON_BAD_FIRMWARE_SIGNATURE, "bad eeprom header");
+  }
+
   return true;
 }
 


### PR DESCRIPTION
this saves a step on a new ESC, making life easier for users
as discussed with @AlkaMotors 