### PR TITLE
修改为高电平时候也跳转到主程序

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -865,7 +865,8 @@ static void checkForSignal()
     delayMicroseconds(10);
   }
   if (low_pin_count == 0) {
-    return;		// pulled high & never low in history - stay in bootloader only
+//    return;		// pulled high & never low in history - stay in bootloader only
+    jump();	
   }
 
   low_pin_count = 0;


### PR DESCRIPTION
![4be1cd89e076e8cf764a9a399d06fa6](https://github.com/user-attachments/assets/b1b1bb4d-da7c-4d4a-85d4-89d887005a2f)
Some receivers have a long high level before binding, which will mistakenly cause the ESC to enter BOOT mode.