### PR TITLE
Increment invalid command if no message received

### DIFF
--- a/bootloader/main.c
+++ b/bootloader/main.c
@@ -789,6 +789,8 @@ static void receiveBuffer()
   }
   if (messagereceived) {
     decodeInput();
+  }else{
+    invalid_command++;
   }
 }
 


### PR DESCRIPTION
If a pulse arrives that is not a valid serial packet. Message received will never be set to 1. The packet will not be processed and invalid command will not be incremented. This stops the bootloader from jumping to main firmware on some signals. The fix increments invalid command on a data pulse that is not recognized as a serial packet.
This fixes elrs receivers and px4 fcs that start with a signal pin in a high state that would get stuck in the bootloader.