### PR TITLE
DroneCAN: fixed bug in memmem()

### DIFF
--- a/bootloader/DroneCAN/DroneCAN.c
+++ b/bootloader/DroneCAN/DroneCAN.c
@@ -820,8 +820,8 @@ static void *memmem(const void *haystack, size_t haystacklen, const void *needle
     if (memcmp(p, needle, needlelen) == 0) {
       return p;
     }
-    haystack = p+1;
     haystacklen -= (p - (const char *)haystack) + 1;
+    haystack = p+1;
   }
   return NULL;
 }


### PR DESCRIPTION
we were miscalculating the haystack length, which could result in reading past the end of flash and getting a hardfault if no app loaded