### PR TITLE
Add support for building on Windows using MSYS2/UCRT64.

### DIFF
--- a/.github/workflows/CI_build_windows_msys2.yml
+++ b/.github/workflows/CI_build_windows_msys2.yml
@@ -1,0 +1,38 @@
+name: CI Build Windows MSYS2 UCRT64
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: 'windows-latest'
+
+    defaults:
+      run:
+        shell: msys2 {0}
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup MSYS2 UCRT64
+        uses: msys2/setup-msys2@v2
+        with:
+          msystem: UCRT64
+          update: true
+          install: >-
+            make
+            unzip
+            tar
+            git
+
+      - name: Build CI
+        run: |
+          make arm_sdk_install
+          make -j8
+
+      - name: Archive build
+        uses: actions/upload-artifact@v4
+        with:
+          name: AM32-bootloader-msys2
+          path: |
+            obj/*.hex
+          retention-days: 7

--- a/Makefile
+++ b/Makefile
@@ -67,12 +67,16 @@ all : check_tools bootloaders
 
 # Check if tools are installed
 check_tools:
+ifeq ($(MSYSTEM),UCRT64)
+	@$(SHELL) -c 'command -v $(CC) >/dev/null 2>&1 || { echo "Error: please install tools first with target arm_sdk_install."; exit 1; }'
+else
 ifeq ($(OS),Windows_NT)
 	@if not exist "$(CC).exe" ( \
 		echo Error: please install tools first with target arm_sdk_install. & exit /B 1 \
 	)
 else
 	@$(SHELL) -c 'command -v $(CC) >/dev/null 2>&1 || { echo "Error: please install tools first with target arm_sdk_install."; exit 1; }'
+endif
 endif
 
 clean :

--- a/make/tools.mk
+++ b/make/tools.mk
@@ -4,6 +4,17 @@
 #
 ###############################################################
 
+ifeq ($(MSYSTEM),UCRT64)
+OSDIR:=windows
+ARM_SDK_PREFIX:=tools/windows/xpack-arm-none-eabi-gcc-10.3.1-2.3/bin/arm-none-eabi-
+CP:=cp
+DSEP:=/
+NUL:=/dev/null
+MKDIR:=mkdir
+RM:=rm
+CUT:=cut
+FGREP:=fgrep
+else
 
 ifeq ($(OS),Windows_NT)
 OSDIR:=windows
@@ -43,6 +54,7 @@ MKDIR:=mkdir
 RM:=rm
 CUT:=cut
 FGREP:=fgrep
+endif
 endif
 endif
 


### PR DESCRIPTION
as per description.

MSYS2: https://www.msys2.org/

I use MSYS2/UCRT64, not WSL, as I don't want to maintain two operating systems, and need to debug code.

With MSYS2/UCRT64 you have have binary compatibility between your build tools and windows IDEs, which you do NOT get with WSL binaries (like GDB, an .elf file) and your IDE (a portable executable/PE file).