### PR TITLE
MCXA133/153 input_pin and linkerscript fix

### DIFF
--- a/Mcu/a153/Inc/blutil.h
+++ b/Mcu/a153/Inc/blutil.h
@@ -22,7 +22,7 @@
 
 #define GPIO_OUTPUT_PUSH_PULL 3	//This variable is unused for MCXA153 but needed to build main.c
 
-#define GPIO_PIN(n) (1U<<(n))
+#define GPIO_PIN(n) (n)
 #define input_GPIO ((GPIO_Type*)(GPIO0_BASE+(0x1000*PORT_LETTER)))
 
 // Link STM GPIO and PORT to NXP ones

--- a/Mcu/a153/MCXA_FLASH.ld
+++ b/Mcu/a153/MCXA_FLASH.ld
@@ -14,7 +14,7 @@ MEMORY
 {
 	PROGRAM_FLASH	(rx)   	: ORIGIN = 0x0, LENGTH = 0x4000 - 32	/* 16K bytes for bootloader */
 	DEVINFO 		(r) 	: ORIGIN = ORIGIN(PROGRAM_FLASH) + LENGTH(PROGRAM_FLASH), LENGTH = 32 
-	EEPROM			(rx)	: ORIGIN = 0x20000 - 0x2000, LENGTH = 0x2000
+	EEPROM			(rx)	: ORIGIN = 0x10000 - 0x2000, LENGTH = 0x2000
   	SRAM 			(rwx)	: ORIGIN = 0x20000000, LENGTH = 0x6000 /* 24K bytes (alias RAM) */  
   	SRAMX0 			(rwx) 	: ORIGIN = 0x4000000, LENGTH = 0x2000 /* 8K bytes (alias RAM2) */  
   	SRAMX1 			(rwx) 	: ORIGIN = 0x4002000, LENGTH = 0x1000 /* 4K bytes (alias RAM3) */  


### PR DESCRIPTION
Fixed bug where input_pin number was not assigned correctly. Changed eeprom range in linkerscript to honor change to 64kB flash.