### PR TITLE
SITL: support Cygwin and recover invalid seeded application checksums

### DIFF
--- a/.github/workflows/SITL.yml
+++ b/.github/workflows/SITL.yml
@@ -2,9 +2,9 @@ name: SITL Tests
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "master"]
   pull_request:
-    branches: ["main"]
+    branches: ["main", "master"]
   workflow_dispatch:
 
 jobs:
@@ -15,6 +15,9 @@ jobs:
 
       - name: Build SITL bootloader
         run: make AM32_SITL_BOOTLOADER_PB4_CAN
+
+      - name: Check seeded application and legacy flash recovery
+        run: python3 Mcu/sitl/test/seed_test.py --bootloader obj/AM32_SITL_BOOTLOADER_PB4_CAN_*.elf --can-uri mcast:8
 
       - name: Get protocol tools from the firmware repo
         uses: actions/checkout@v4
@@ -41,3 +44,19 @@ jobs:
         with:
           name: sitl-bootloader-test-log
           path: sitl_test_run/bl_test.log
+
+  cygwin-bootloader-tests:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: cygwin/cygwin-install-action@v4
+        with:
+          packages: gcc-core make python3 git
+      - name: Build and test Cygwin bootloader
+        shell: C:\cygwin\bin\bash.exe --noprofile --norc -o igncr -eo pipefail '{0}'
+        run: |
+          export PATH=/usr/bin:$PATH
+          cd "$(cygpath -u "$GITHUB_WORKSPACE")"
+          git config --global --add safe.directory "$PWD"
+          make -j8 OS=Linux SHELL=/bin/bash AM32_SITL_BOOTLOADER_PB4_CAN
+          python3 Mcu/sitl/test/seed_test.py --bootloader obj/AM32_SITL_BOOTLOADER_PB4_CAN_*.elf --can-uri mcast:8

--- a/Mcu/sitl/README.md
+++ b/Mcu/sitl/README.md
@@ -1,6 +1,6 @@
 # AM32 bootloader SITL
 
-Runs the unmodified bootloader as a native Linux process for testing
+Runs the unmodified bootloader as a native Linux or Cygwin process for testing
 the input-type detection, the 19200 baud 4-way configuration protocol
 and the DroneCAN bootloader flows without hardware.
 
@@ -9,6 +9,23 @@ Build and run:
 ```
 make AM32_SITL_BOOTLOADER_PB4_CAN
 ./obj/AM32_SITL_BOOTLOADER_PB4_CAN_*.elf --eeprom test_ee.bin --can-uri none
+```
+
+On Windows, install Cygwin's `gcc-core`, `make`, `python3` and `git`
+packages, then build from its Bash shell:
+
+```
+make OS=Linux SHELL=/bin/bash AM32_SITL_BOOTLOADER_PB4_CAN
+```
+
+`OS=Linux` selects the POSIX build tools. The linker uses a fixed PE image
+base below 4 GB so protocol addresses remain representable. The `.elf`
+output is a Cygwin Windows executable and requires `cygwin1.dll`.
+
+Check startup, legacy seeded-flash recovery and multicast initialisation:
+
+```
+python3 Mcu/sitl/test/seed_test.py --bootloader obj/AM32_SITL_BOOTLOADER_PB4_CAN_V19.elf --can-uri mcast:8
 ```
 
 Run with `--help` for all options. Key points:

--- a/Mcu/sitl/Src/eeprom.c
+++ b/Mcu/sitl/Src/eeprom.c
@@ -28,6 +28,7 @@
 // must match EEPROM_START_ADD for BOARD_FLASH_SIZE=128 in main.c
 #define EEPROM_OFFSET 0x1F800
 #define APP_OFFSET 0x4000 // FIRMWARE_RELATIVE_START for CAN builds
+#define SEEDED_APP_SIZE (8 * 1024)
 
 static uint8_t* flash;
 static int flash_fd = -1;
@@ -53,16 +54,21 @@ static uint32_t bl_crc32(const uint8_t* buf, uint32_t size)
   jump() stack/entry checks and an app_signature block that passes
   DroneCAN_boot_ok(), so the boot gates behave as with a programmed ESC
  */
-static void seed_flash(void)
+static void seed_app(uint8_t* app, bool legacy)
 {
-    memset(flash, 0xFF, FLASH_SIZE);
-    uint8_t* app = flash + APP_OFFSET;
-    const uint32_t app_len = 8 * 1024;
+    const uint32_t app_len = SEEDED_APP_SIZE;
     memset(app, 0, app_len);
     const uint32_t sp = 0x20004000; // inside RAM
     const uint32_t entry = FLASH_BASE_ADDR + APP_OFFSET + 0x101;
     memcpy(app, &sp, 4);
     memcpy(app + 4, &entry, 4);
+
+    // Include the name in CRC1. Writing it after the signature was
+    // calculated left the simulated application unable to pass boot checks.
+    static const char fwname[] = "AM32_SITL_CAN";
+    if (!legacy) {
+        memcpy(app + 512, fwname, sizeof(fwname));
+    }
 
     // app_signature at an aligned offset near the end of the image,
     // layout from bootloader/DroneCAN/DroneCAN.c
@@ -83,13 +89,28 @@ static void seed_flash(void)
     sig.crc2 = bl_crc32(app + sig_ofs + sizeof(sig), app_len - (sig_ofs + sizeof(sig)));
     memcpy(app + sig_ofs, &sig, sizeof(sig));
 
-    // firmware name, at the CAN layout's .file_name location: just
-    // after the vector-table region at the start of the app, matching
-    // what devinfo.filename_start now advertises. Without it the
-    // config tool reads erased 0xFF flash and shows a garbage name
-    static const char fwname[] = "AM32_SITL_CAN";
-    memset(flash + APP_OFFSET + 512, 0, 30);
-    memcpy(flash + APP_OFFSET + 512, fwname, sizeof(fwname) - 1);
+    // Reproduce the old synthetic image only to recognise it for repair.
+    if (legacy) {
+        memcpy(app + 512, fwname, sizeof(fwname));
+    }
+}
+
+static void seed_flash(void)
+{
+    memset(flash, 0xFF, FLASH_SIZE);
+    seed_app(flash + APP_OFFSET, false);
+}
+
+static void repair_legacy_seed(void)
+{
+    uint8_t legacy[SEEDED_APP_SIZE];
+    seed_app(legacy, true);
+    // Match the entire old synthetic application, not merely a bad CRC:
+    // never repair or replace firmware uploaded through the configurator.
+    if (memcmp(flash + APP_OFFSET, legacy, sizeof(legacy)) == 0) {
+        seed_app(flash + APP_OFFSET, false);
+        fprintf(stderr, "SITL: repaired legacy seeded application CRC\n");
+    }
 }
 
 void sitl_bl_flash_init(void)
@@ -132,6 +153,8 @@ void sitl_bl_flash_init(void)
     if (fresh) {
         fprintf(stderr, "SITL: seeding flash image %s\n", path);
         seed_flash();
+    } else {
+        repair_legacy_seed();
     }
 
     // mirror the shared eeprom file into the eeprom page: the app may

--- a/Mcu/sitl/Src/sys_can_SITL.c
+++ b/Mcu/sitl/Src/sys_can_SITL.c
@@ -130,7 +130,12 @@ void sys_can_init(void)
     }
     const int one = 1;
     setsockopt(fd_in, SOL_SOCKET, SO_REUSEADDR, &one, sizeof(one));
-    if (bind(fd_in, (struct sockaddr*)&addr, sizeof(addr)) != 0) {
+    struct sockaddr_in bind_addr = addr;
+#ifdef __CYGWIN__
+    // Windows cannot bind a multicast group address.
+    bind_addr.sin_addr.s_addr = htonl(INADDR_ANY);
+#endif
+    if (bind(fd_in, (struct sockaddr*)&bind_addr, sizeof(bind_addr)) != 0) {
         perror("SITL: can bind");
         exit(1);
     }
@@ -169,6 +174,9 @@ void sys_can_init(void)
       rebinding the sender to 127.0.0.1 if not (see the firmware SITL
       driver for the routing background)
      */
+#ifndef __CYGWIN__
+    // Cygwin poll() does not reliably report multicast. Keep Windows on
+    // its normal multicast interface instead of rebinding to loopback.
     for (int attempt = have_if ? 1 : 0; attempt < 2; attempt++) {
         uint8_t probe[4] = { 0xde, 0xad, 0xbe, 0xef }; // wrong magic, ignored
         send(fd_out, probe, sizeof(probe), 0);
@@ -201,6 +209,8 @@ void sys_can_init(void)
             fprintf(stderr, "SITL: WARNING: CAN multicast self test failed for %s\n", address);
         }
     }
+
+#endif
 
     // after the self test, which may have rebound fd_out
     socklen_t alen = sizeof(tx_addr);

--- a/Mcu/sitl/test/seed_test.py
+++ b/Mcu/sitl/test/seed_test.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Check real bootloader startup and recovery of old synthetic flash images."""
+import argparse
+from pathlib import Path
+import socket
+import struct
+import subprocess
+import tempfile
+import zlib
+
+
+APP = 0x4000
+SIGNATURE = APP + 7168
+CRC1 = SIGNATURE + 12
+EEPROM = 0x1f800
+
+
+def legacy_image(settings):
+    # Reproduce the image shipped before the firmware name was included
+    # in CRC1. Keep the historical CRC literal so this fixture does not
+    # accidentally follow changes to the seeding implementation.
+    image = bytearray(b'\xff' * (128 * 1024))
+    image[APP:APP + 8192] = bytes(8192)
+    struct.pack_into('<II', image, APP, 0x20004000, 0x08004101)
+    image[APP + 512:APP + 525] = b'AM32_SITL_CAN\0'
+    struct.pack_into('<IIIII16sII', image, SIGNATURE,
+                     0x68f058e6, 0xafcee5a0, 8192, 0x62ac7feb, 0,
+                     b'SITL', 0, 0)
+    image[EEPROM:EEPROM + len(settings)] = settings
+    return image
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--bootloader', required=True)
+    ap.add_argument('--can-uri', default='none')
+    args = ap.parse_args()
+    binary = str(Path(args.bootloader).resolve())
+    with tempfile.TemporaryDirectory(prefix='am32-bl-seed-') as tmp:
+        ee = Path(tmp) / 'settings.bin'
+        # Recognisable settings bytes; recovery must preserve every byte.
+        settings = bytes([1]) + bytes(range(1, 192))
+        ee.write_bytes(settings)
+        flash = Path(str(ee) + '.blflash')
+
+        def boot(expect_jump=True):
+            with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as reservation:
+                reservation.bind(('127.0.0.1', 0))
+                port = reservation.getsockname()[1]
+            proc = subprocess.Popen([binary, '--eeprom', str(ee),
+                                     '--input-port', str(port), '--can-uri', args.can_uri],
+                                    stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+            try:
+                try:
+                    output = proc.communicate(timeout=10 if expect_jump else 3)[0]
+                except subprocess.TimeoutExpired:
+                    assert not expect_jump, 'bootloader did not jump to the application'
+                    proc.terminate()
+                    output = proc.communicate(timeout=5)[0]
+                else:
+                    assert expect_jump and proc.returncode == 42, output.decode(errors='replace')
+                assert ee.read_bytes() == settings, 'EEPROM settings changed'
+                return output
+            finally:
+                if proc.poll() is None:
+                    proc.kill()
+                    proc.communicate()
+
+        boot()
+        fresh = flash.read_bytes()
+        crc = zlib.crc32(fresh[APP:SIGNATURE], 0xffffffff) ^ 0xffffffff
+        assert struct.unpack_from('<I', fresh, CRC1)[0] == crc
+        print('PASS: freshly seeded application passes the real boot gate')
+
+        legacy = legacy_image(settings)
+        legacy[0x100] = 0x42  # unrelated flash must survive recovery
+        flash.write_bytes(legacy)
+        assert b'repaired legacy' in boot()
+        expected = bytearray(legacy)
+        struct.pack_into('<I', expected, CRC1, crc)
+        assert flash.read_bytes() == expected, 'recovery changed more than CRC1'
+        assert b'repaired legacy' not in boot()
+        assert flash.read_bytes() == expected
+        print('PASS: legacy CRC repaired once, preserving settings and unrelated flash')
+
+        # An uploaded or damaged image must still fail validation, even
+        # if it resembles the old dummy image and has the same stale CRC.
+        legacy[APP + 1024] ^= 1
+        flash.write_bytes(legacy)
+        assert b'repaired legacy' not in boot(expect_jump=False)
+        assert flash.read_bytes() == legacy
+        print('PASS: modified firmware is neither repaired nor booted')
+
+
+if __name__ == '__main__':
+    main()

--- a/sitlmakefile.mk
+++ b/sitlmakefile.mk
@@ -39,7 +39,13 @@ endif
 
 # -no-pie so the fixed flash mapping at 0x08000000 and the devinfo
 # address fit in the protocol's 32 bit addresses
+ifneq ($(filter CYGWIN%,$(UNAME_S)),)
+# PE defaults to an image base above 4 GB. Keep devinfo pointers within
+# the wire protocol's 32-bit address range and clear of mapped flash.
+LDFLAGS_COMMON_$(MCU) := -Wl,--image-base,0x400000,--disable-dynamicbase $(SITL_SAN_FLAGS)
+else
 LDFLAGS_COMMON_$(MCU) := -no-pie $(SITL_SAN_FLAGS)
+endif
 
 SRC_$(MCU)_BL := $(wildcard $(HAL_FOLDER_$(MCU))/Src/*.c)
 


### PR DESCRIPTION
The native bootloader fails under Cygwin when binding its CAN multicast socket, and the default PE image base puts devinfo pointers outside the protocol's 32-bit address range. Bind to INADDR_ANY while retaining multicast group membership, skip the unreliable Cygwin multicast self-test, and link the host executable below 4 GB.

Also fix the synthetic application's CRC: the firmware name was written after CRC1 was calculated, preventing the bootloader from starting the simulated application. Existing images are repaired only when the entire application matches the old synthetic seed; EEPROM settings and uploaded firmware are preserved.

Adds standalone startup and legacy-image recovery tests on Linux and Windows/Cygwin, and enables the SITL workflow for this repository's master branch. These changes let the AM32 Windows packager use an upstream bootloader revision without carrying a source patch.

Validation:
- Linux: complete existing bootloader protocol, boot-gate and DroneCAN update suite passed.
- Linux and win11/Cygwin: fresh startup, exact legacy recovery, preservation of settings and rejection of modified firmware passed with multicast enabled.
- win11: AM32 packaged GUI build passed, including bootloader handoff, motor operation, paths with spaces and teardown.
