### PR TITLE
add _FROM4k bootloader updaters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,9 @@ endef
 MCU_TYPES := $(sort $(foreach mcu,$(MCU_BUILDS),$(call base_mcu,$(mcu))))
 
 # custom per-board targets defined in Inc/targets.h, parsed by make/parse_targets.py.
-# BOARD_TARGETS entries are "BUILD|TAG|BOARDDEFINE", e.g. G431_CAN|ARKG4|ARK_G431_CAN
+# BOARD_TARGETS entries are "BUILD|TAG|BOARDDEFINE|PIN", e.g.
+# G431_CAN|ARKG4|ARK_G431_CAN|PB4. The tag names the build, the pin is the
+# board's real bootloader comms pin and is what goes in the amj file
 BOARD_TARGETS := $(shell python3 make/parse_targets.py builds)
 BOARD_MCUS := $(shell python3 make/parse_targets.py mcus)
 # make sure each custom board's per-MCU makefile gets included below
@@ -171,6 +173,9 @@ define CREATE_BOOTLOADER_TARGET
 $(eval BUILD := $(1))
 $(eval PIN := $(2))
 $(eval BOARD := $(3))
+# for a board target the build is named by its tag, but the amj file has to
+# name the pin the bootloader really listens on
+$(eval COMMS_PIN := $(if $(4),$(4),$(2)))
 $(eval MCU := $$(call base_mcu,$$(1)))
 $(eval EXTRA_CFLAGS := $(call get_cflags,$(1)))
 $(eval ELF_FILE := $(BIN_DIR)/$(call BOOTLOADER_BASENAME_VER,$(BUILD),$(PIN)).elf)
@@ -241,7 +246,7 @@ $(BLU_BIN_FILE): $$(BLU_ELF_FILE)
 
 $(BLU_AMJ_FILE): $$(BLU_BIN_FILE)
 	$$(QUIET)echo Generating $(notdir $$@)
-	$$(QUIET)python3 bl_update/make_amj.py --type bl_update --githash $(shell git rev-parse HEAD) $(BLU_HEX_FILE) $(BLU_AMJ_FILE)
+	$$(QUIET)python3 bl_update/make_amj.py --type bl_update --pin $(COMMS_PIN) --githash $(shell git rev-parse HEAD) $(BLU_HEX_FILE) $(BLU_AMJ_FILE)
 
 $(TARGET): $$(if $(NATIVE_$(MCU)),$$(ELF_FILE),$$(HEX_FILE))
 
@@ -260,6 +265,7 @@ define CREATE_TRANSITION_TARGET
 $(eval BUILD := $(1))
 $(eval PIN := $(2))
 $(eval BOARD := $(3))
+$(eval COMMS_PIN := $(if $(4),$(4),$(2)))
 $(eval MCU := $$(call base_mcu,$$(1)))
 $(eval EXTRA_CFLAGS := $(call get_cflags,$(1)))
 $(eval H_FILE := $(BIN_DIR)/$(call BOOTLOADER_BASENAME_VER,$(BUILD),$(PIN)).h)
@@ -293,7 +299,7 @@ $(BLT_HEX_FILE): $$(BLT_ELF_FILE)
 
 $(BLT_AMJ_FILE): $$(BLT_HEX_FILE)
 	$$(QUIET)echo Generating $(notdir $$@)
-	$$(QUIET)python3 bl_update/make_amj.py --type bl_update --githash $(shell git rev-parse HEAD) $(BLT_HEX_FILE) $(BLT_AMJ_FILE)
+	$$(QUIET)python3 bl_update/make_amj.py --type bl_update --pin $(COMMS_PIN) --githash $(shell git rev-parse HEAD) $(BLT_HEX_FILE) $(BLT_AMJ_FILE)
 
 $(BLT_TARGET): $$(BLT_AMJ_FILE)
 
@@ -306,7 +312,7 @@ pins_for_build = $(if $(BOOTLOADER_PINS_$(call base_mcu,$1)),$(BOOTLOADER_PINS_$
 $(foreach BUILD,$(MCU_BUILDS),$(foreach PIN,$(call pins_for_build,$(BUILD)),$(eval $(call CREATE_BOOTLOADER_TARGET,$(BUILD),$(PIN)))$(if $(call has_transition,$(BUILD)),$(eval $(call CREATE_TRANSITION_TARGET,$(BUILD),$(PIN))))))
 
 # custom per-board targets from Inc/targets.h (BUILD|TAG|BOARDDEFINE)
-$(foreach B,$(BOARD_TARGETS),$(eval $(call CREATE_BOOTLOADER_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B)))))$(if $(call has_transition,$(word 1,$(subst |, ,$(B)))),$(eval $(call CREATE_TRANSITION_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B)))))))
+$(foreach B,$(BOARD_TARGETS),$(eval $(call CREATE_BOOTLOADER_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B))),$(word 4,$(subst |, ,$(B)))))$(if $(call has_transition,$(word 1,$(subst |, ,$(B)))),$(eval $(call CREATE_TRANSITION_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B))),$(word 4,$(subst |, ,$(B)))))))
 
 bootloaders: $(ALL_BUILDS)
 

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,10 @@ BIN_DIR := $(ROOT)/$(OBJ)
 # find the SVD files
 $(foreach MCU,$(MCU_TYPES),$(eval SVD_$(MCU) := $(wildcard $(HAL_FOLDER_$(MCU))/*.svd)))
 
+# a recipe that fails must not leave its target behind: a hex that failed
+# its layout check would otherwise look up to date on the next build
+.DELETE_ON_ERROR:
+
 .PHONY : clean all
 all : check_tools bootloaders
 
@@ -106,6 +110,7 @@ LDSCRIPT_BL := bootloader/ldscript_bl.ld
 LDSCRIPT_BL_CAN := bootloader/ldscript_bl_CAN.ld
 LDSCRIPT_BLU := bl_update/ldscript_bl.ld
 LDSCRIPT_BLU_CAN := bl_update/ldscript_bl_CAN.ld
+LDSCRIPT_BLT := bl_update/ldscript_bl_transition.ld
 
 # Function to extract CFLAGS based on target name
 get_flash_size = $(if $(filter %K,$(word 2,$(subst _, ,$1))),-DBOARD_FLASH_SIZE=$(subst K,,$(word 2,$(subst _, ,$1))))
@@ -133,6 +138,11 @@ define BOOTLOADER_UPDATE_BASENAME
 $(IDENTIFIER)_$(call base_mcu,$(1))_BL_UPDATER_$(2)$(call get_k_tag,$(1))
 endef
 
+# a transition updater is one that is flashed by a legacy 4k bootloader
+define BOOTLOADER_TRANSITION_BASENAME
+$(call BOOTLOADER_UPDATE_BASENAME,$(1),$(2))_FROM4K
+endef
+
 # bootloader target names with version for filename
 define BOOTLOADER_BASENAME_VER
 $(call BOOTLOADER_BASENAME,$(1),$(2))_V$(BOOTLOADER_VERSION)
@@ -142,6 +152,15 @@ endef
 define BOOTLOADER_UPDATE_BASENAME_VER
 $(call BOOTLOADER_UPDATE_BASENAME,$(1),$(2))_V$(BOOTLOADER_VERSION)
 endef
+
+define BOOTLOADER_TRANSITION_BASENAME_VER
+$(call BOOTLOADER_TRANSITION_BASENAME,$(1),$(2))_V$(BOOTLOADER_VERSION)
+endef
+
+# a transition updater is only built for CAN builds on MCUs where the legacy
+# 4k bootloader used the 64k flash layout, so that the updater fits between
+# the 16k CAN bootloader and the legacy eeprom
+has_transition = $(if $(call has_can_suffix,$1),$(BL_TRANSITION_$(call base_mcu,$1)))
 
 # list of targets formed using CREATE_BOOTLOADER_TARGET
 ALL_BUILDS :=
@@ -197,7 +216,7 @@ $(if $(NATIVE_$(MCU)),,	$$(QUIET)$$(CP) -f $$@ $$(OBJ)$$(DSEP)debug.elf
 $(H_FILE): $(BIN_FILE)
 	$$(QUIET)python3 bl_update/make_binheader.py $(BIN_FILE) $(H_FILE)
 
-$(BLU_ELF_FILE): CFLAGS_BLU := -DAM32_MCU=\"$(MCU)\" $$(MCU_$(MCU)) $$(CFLAGS_$(MCU)) $$(CFLAGS_BASE) -DBOOTLOADER -DUSE_$(PIN) $(if $(BOARD),-D$(BOARD)) $(EXTRA_CFLAGS) -Wno-unused-variable -Wno-unused-function
+$(BLU_ELF_FILE): CFLAGS_BLU := -DAM32_MCU=\"$(MCU)\" $$(MCU_$(MCU)) $$(CFLAGS_$(MCU)) $$(CFLAGS_BASE) -DBOOTLOADER -DUSE_$(PIN) $(if $(BOARD),-D$(BOARD)) $(EXTRA_CFLAGS) -DBL_TRANSITION=0 -Wno-unused-variable -Wno-unused-function
 $(BLU_ELF_FILE): LDFLAGS_BLU := $$(LDFLAGS_COMMON) $$(LDFLAGS_$(MCU)) -T$(xBLU_LDSCRIPT)
 $(BLU_ELF_FILE): $$(SRC_$(MCU)_BL) $$(SRC_BLU) $(H_FILE)
 	$$(QUIET)echo building bootloader updater for $(BUILD) with pin $(PIN)
@@ -233,13 +252,61 @@ ALL_BUILDS := $(ALL_BUILDS) $(TARGET)
 BLU_BUILDS := $(BLU_BUILDS) $(if $(NATIVE_$(MCU)),,$(BLU_TARGET))
 endef
 
+# create a transition updater build target, which is the same updater firmware
+# linked to be flashed by a legacy 4k bootloader over the top of the
+# application. It carries no valid app signature, as it is left behind in the
+# application area once it has run and must never be booted
+define CREATE_TRANSITION_TARGET
+$(eval BUILD := $(1))
+$(eval PIN := $(2))
+$(eval BOARD := $(3))
+$(eval MCU := $$(call base_mcu,$$(1)))
+$(eval EXTRA_CFLAGS := $(call get_cflags,$(1)))
+$(eval H_FILE := $(BIN_DIR)/$(call BOOTLOADER_BASENAME_VER,$(BUILD),$(PIN)).h)
+$(eval BLT_ELF_FILE := $(BIN_DIR)/$(call BOOTLOADER_TRANSITION_BASENAME_VER,$(BUILD),$(PIN)).elf)
+$(eval BLT_HEX_FILE := $(BLT_ELF_FILE:.elf=.hex))
+$(eval BLT_DEP_FILE := $(BLT_ELF_FILE:.elf=.d))
+$(eval BLT_MAP_FILE := $(BLT_ELF_FILE:.elf=.map))
+$(eval BLT_AMJ_FILE := $(BLT_ELF_FILE:.elf=.amj))
+$(eval BLT_TARGET := $(call BOOTLOADER_TRANSITION_BASENAME,$(BUILD),$(PIN)))
+
+$(eval xCC := $(if $($(MCU)_CC), $($(MCU)_CC), $(CC)))
+$(eval xOBJCOPY := $(if $($(MCU)_OBJCOPY), $($(MCU)_OBJCOPY), $(OBJCOPY)))
+$(eval xBLT_LDSCRIPT := $(if $($(MCU)_LDSCRIPT_BLT), $($(MCU)_LDSCRIPT_BLT), $(LDSCRIPT_BLT)))
+
+-include $(BLT_DEP_FILE)
+
+$(BLT_ELF_FILE): CFLAGS_BLT := -DAM32_MCU=\"$(MCU)\" $$(MCU_$(MCU)) $$(CFLAGS_$(MCU)) $$(CFLAGS_BASE) -DBOOTLOADER -DUSE_$(PIN) $(if $(BOARD),-D$(BOARD)) $(EXTRA_CFLAGS) -DBL_TRANSITION=1 -Wno-unused-variable -Wno-unused-function
+$(BLT_ELF_FILE): LDFLAGS_BLT := $$(LDFLAGS_COMMON) $$(LDFLAGS_$(MCU)) -T$(xBLT_LDSCRIPT)
+$(BLT_ELF_FILE): $$(SRC_$(MCU)_BL) $$(SRC_BLU) $(H_FILE)
+	$$(QUIET)echo building transition bootloader updater for $(BUILD) with pin $(PIN)
+	$$(QUIET)$$(MKDIR) -p $(OBJ)
+	$$(QUIET)echo Compiling $(notdir $$@)
+	$$(QUIET)$(xCC) $$(CFLAGS_BLT) $$(LDFLAGS_BLT) -MMD -MP -MF $(BLT_DEP_FILE) -o $$(@) $$(SRC_$(MCU)_BL) $$(SRC_BLU) -I. -DBL_HEADER_FILE=$(H_FILE) -Wl,-Map=$(BLT_MAP_FILE)
+
+# only a hex is generated: the image has a gap between the entry vector and
+# the code, which the flashing client fills in
+$(BLT_HEX_FILE): $$(BLT_ELF_FILE)
+	$$(QUIET)echo Generating $(notdir $$@)
+	$$(QUIET)$(xOBJCOPY) $$(<) -O ihex $$(@)
+	$$(QUIET)python3 bl_update/check_transition.py $$(@)
+
+$(BLT_AMJ_FILE): $$(BLT_HEX_FILE)
+	$$(QUIET)echo Generating $(notdir $$@)
+	$$(QUIET)python3 bl_update/make_amj.py --type bl_update --githash $(shell git rev-parse HEAD) $(BLT_HEX_FILE) $(BLT_AMJ_FILE)
+
+$(BLT_TARGET): $$(BLT_AMJ_FILE)
+
+BLU_BUILDS := $(BLU_BUILDS) $(BLT_TARGET)
+endef
+
 # choose per-MCU pin override if set, otherwise the global BOOTLOADER_PINS
 pins_for_build = $(if $(BOOTLOADER_PINS_$(call base_mcu,$1)),$(BOOTLOADER_PINS_$(call base_mcu,$1)),$(BOOTLOADER_PINS))
 
-$(foreach BUILD,$(MCU_BUILDS),$(foreach PIN,$(call pins_for_build,$(BUILD)),$(eval $(call CREATE_BOOTLOADER_TARGET,$(BUILD),$(PIN)))))
+$(foreach BUILD,$(MCU_BUILDS),$(foreach PIN,$(call pins_for_build,$(BUILD)),$(eval $(call CREATE_BOOTLOADER_TARGET,$(BUILD),$(PIN)))$(if $(call has_transition,$(BUILD)),$(eval $(call CREATE_TRANSITION_TARGET,$(BUILD),$(PIN))))))
 
 # custom per-board targets from Inc/targets.h (BUILD|TAG|BOARDDEFINE)
-$(foreach B,$(BOARD_TARGETS),$(eval $(call CREATE_BOOTLOADER_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B))))))
+$(foreach B,$(BOARD_TARGETS),$(eval $(call CREATE_BOOTLOADER_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B)))))$(if $(call has_transition,$(word 1,$(subst |, ,$(B)))),$(eval $(call CREATE_TRANSITION_TARGET,$(word 1,$(subst |, ,$(B))),$(word 2,$(subst |, ,$(B))),$(word 3,$(subst |, ,$(B)))))))
 
 bootloaders: $(ALL_BUILDS)
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,32 @@ environment is setup correctly you should be able to tab complete the
 available targets. Otherwise you can run "make targets" to see the
 available build targets.
 
+Bootloader Updaters
+-------------------
+
+A bootloader updater is a small firmware that carries a bootloader
+image inside it. It is flashed as if it were the main application, and
+on boot it writes the bootloader it carries into place and resets. This
+lets a bootloader be replaced without a SWD debugger. Run "make
+updater_targets" to see the available updaters, or "make updaters" to
+build them all.
+
+An updater named AM32_<MCU>_BL_UPDATER_<PIN>_CAN_FROM4K_V<n> is a
+transition updater. Use it to move an ESC that shipped with a 4k
+non-CAN bootloader onto a 16k DroneCAN bootloader, which the normal CAN
+updater cannot do as it needs the 16k bootloader to already be
+installed. The transition updater has its entry point at 0x08001000
+where the 4k bootloader starts the application, while its code and the
+bootloader image it carries sit above 0x08004000, out of the way of the
+region it erases. A CAN bootloader keeps its settings at the 128k layout
+address rather than where the 4k bootloader kept them, and the
+transition updater leaves that page blank.
+
+The main firmware is erased in the process, so flash a matching CAN main
+firmware once the new bootloader is in place, then configure the ESC
+from scratch with the configurator or the DroneCAN GUI tool. Until it is
+configured the new bootloader will not boot the application.
+
 CI Builds
 ---------
 

--- a/bl_update/check_transition.py
+++ b/bl_update/check_transition.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+'''
+check the layout of a transition bootloader updater hex
+
+The transition updater is flashed by a legacy 4k bootloader over the top of
+the application, so getting its layout wrong would leave an ESC that needs a
+debugger to recover. Check the invariants it relies on.
+'''
+
+import struct
+import sys
+from argparse import ArgumentParser
+
+LEGACY_APP_START = 0x08001000  # where a 4k bootloader starts the application
+CODE_START = 0x08004000        # first address above the new 16k bootloader
+LEGACY_EEPROM = 0x0800F800     # eeprom of the 64k flash layout
+RAM_START = 0x20000000
+RAM_END = RAM_START + 112*1024
+
+APP_SIGNATURE_MAGIC1 = 0x68f058e6
+APP_SIGNATURE_MAGIC2 = 0xafcee5a0
+
+
+def parse_hex(path):
+    '''parse an intel hex file, filling gaps with 0xff as the flashing clients do'''
+    upper = 0
+    origin = None
+    next_address = 0
+    img = bytearray()
+    for line in open(path, "r"):
+        line = line.strip()
+        if line == "":
+            continue
+        rec = bytes.fromhex(line[1:])
+        count, rtype, data = rec[0], rec[3], rec[4:4+rec[0]]
+        address = upper + ((rec[1] << 8) | rec[2])
+        if rtype == 0x00:
+            if origin is None:
+                origin = address
+                next_address = address
+            if address < next_address:
+                raise Exception("out of order record at 0x%08x" % address)
+            img += b'\xff' * (address - next_address)
+            img += data
+            next_address = address + count
+        elif rtype == 0x04:
+            upper = ((data[0] << 8) | data[1]) << 16
+    if origin is None:
+        raise Exception("no data records")
+    return origin, bytes(img)
+
+
+def check(path):
+    origin, img = parse_hex(path)
+    end = origin + len(img)
+    if origin != LEGACY_APP_START:
+        raise Exception("origin is 0x%08x, expected 0x%08x" % (origin, LEGACY_APP_START))
+    if end > LEGACY_EEPROM:
+        raise Exception("image ends at 0x%08x, past the legacy eeprom 0x%08x" % (end, LEGACY_EEPROM))
+
+    stack, entry = struct.unpack("<II", img[:8])
+    if stack < RAM_START or stack > RAM_END:
+        raise Exception("stack pointer 0x%08x is not in ram" % stack)
+    if (entry & 1) == 0:
+        raise Exception("entry point 0x%08x is not thumb" % entry)
+    if (entry & ~1) < CODE_START or (entry & ~1) >= end:
+        raise Exception("entry point 0x%08x is not in the code region" % entry)
+
+    # everything below the code must be the flashing client's gap fill, else
+    # the updater would be erasing its own code as it runs
+    if set(img[8:CODE_START-origin]) not in ({0xff}, set()):
+        raise Exception("image has content below 0x%08x" % CODE_START)
+
+    # the updater is left behind in the application area, so the new
+    # bootloader must never accept it as an application
+    sig = struct.pack("<II", APP_SIGNATURE_MAGIC1, APP_SIGNATURE_MAGIC2)
+    ofs = img.find(sig, CODE_START-origin)
+    if ofs < 0:
+        raise Exception("no app signature found")
+    fwlen, = struct.unpack("<I", img[ofs+8:ofs+12])
+    if fwlen != 0xFFFFFFFF:
+        raise Exception("app signature length is %#x, expected an unbootable 0xffffffff" % fwlen)
+
+
+parser = ArgumentParser(description=__doc__)
+parser.add_argument("hex", help="transition updater hex file")
+args = parser.parse_args()
+
+try:
+    check(args.hex)
+except Exception as ex:
+    print("%s: %s" % (args.hex, ex))
+    sys.exit(1)

--- a/bl_update/ldscript_bl_transition.ld
+++ b/bl_update/ldscript_bl_transition.ld
@@ -1,0 +1,160 @@
+/*
+       linker file for the AM32 transition bootloader updater
+
+       This image is flashed by a legacy 4k (non-CAN) bootloader, so the
+       vector table the legacy bootloader jumps to must sit at the legacy
+       application start of 0x08001000. Everything else has to live above
+       the 16k that the new CAN bootloader will occupy, as the updater
+       erases and rewrites that region while running.
+
+       The flash region stops at 0x0800f800, the eeprom of the 64k flash
+       layout used by the legacy bootloader, whose settings we migrate.
+*/
+
+/* Entry Point */
+ENTRY(Reset_Handler)
+
+_estack = 0x20001000;    /* end of RAM */
+_Min_Heap_Size = 0x200;      /* required amount of heap  */
+_Min_Stack_Size = 0x400; /* required amount of stack */
+
+/* Specify the memory areas */
+MEMORY
+{
+STUB (rx)       : ORIGIN = 0x08001000, LENGTH = 8
+FLASH (rx)      : ORIGIN = 0x08004000, LENGTH = 46K
+RAM (xrw)       : ORIGIN = 0x20000000, LENGTH = 4K
+}
+
+/* Define output sections */
+SECTIONS
+{
+  /* the stack pointer and entry point the legacy bootloader jumps to */
+  .stub_vector :
+  {
+    KEEP(*(.stub_vector))
+  } >STUB
+
+  /* The startup code goes first into FLASH */
+  .isr_vector :
+  {
+    . = ALIGN(4);
+    KEEP(*(.isr_vector)) /* Startup code */
+    . = ALIGN(4);
+    KEEP(*(.app_signature))
+    . = ALIGN(4);
+  } >FLASH
+
+  /* The program code and other data goes into FLASH */
+  .text :
+  {
+    . = ALIGN(4);
+    *(.text)           /* .text sections (code) */
+    *(.text*)          /* .text* sections (code) */
+    *(.glue_7)         /* glue arm to thumb code */
+    *(.glue_7t)        /* glue thumb to arm code */
+    *(.eh_frame)
+
+    KEEP (*(.init))
+    KEEP (*(.fini))
+
+    . = ALIGN(4);
+    _etext = .;        /* define a global symbols at end of code */
+  } >FLASH
+
+  /* Constant data goes into FLASH */
+  .rodata :
+  {
+    . = ALIGN(4);
+    *(.rodata)         /* .rodata sections (constants, strings, etc.) */
+    *(.rodata*)        /* .rodata* sections (constants, strings, etc.) */
+    . = ALIGN(4);
+  } >FLASH
+
+  .ARM.extab   : { *(.ARM.extab* .gnu.linkonce.armextab.*) } >FLASH
+  .ARM : {
+    __exidx_start = .;
+    *(.ARM.exidx*)
+    __exidx_end = .;
+  } >FLASH
+
+  .preinit_array     :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array*))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } >FLASH
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT(.init_array.*)))
+    KEEP (*(.init_array*))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } >FLASH
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT(.fini_array.*)))
+    KEEP (*(.fini_array*))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } >FLASH
+
+  /* used by the startup to initialize data */
+  _sidata = LOADADDR(.data);
+
+  /* Initialized data sections goes into RAM, load LMA copy after code */
+  .data : 
+  {
+    . = ALIGN(4);
+    _sdata = .;        /* create a global symbol at data start */
+    *(.data)           /* .data sections */
+    *(.data*)          /* .data* sections */
+
+    . = ALIGN(4);
+    _edata = .;        /* define a global symbol at data end */
+  } >RAM AT> FLASH
+
+  /* Uninitialized data section */
+  . = ALIGN(4);
+  .bss :
+  {
+    /* This is used by the startup in order to initialize the .bss secion */
+    _sbss = .;         /* define a global symbol at bss start */
+    __bss_start__ = _sbss;
+    *(.bss)
+    *(.bss*)
+    *(COMMON)
+
+    . = ALIGN(4);
+    _ebss = .;         /* define a global symbol at bss end */
+    __bss_end__ = _ebss;
+  } >RAM
+
+  /* User_heap_stack section, used to check that there is enough RAM left */
+  ._user_heap_stack :
+  {
+    . = ALIGN(8);
+    PROVIDE ( end = . );
+    PROVIDE ( _end = . );
+    . = . + _Min_Heap_Size;
+    . = . + _Min_Stack_Size;
+    . = ALIGN(8);
+  } >RAM
+
+  /* Ensure flash content is padded to 32 bytes with 0xFF */
+  .padding :
+  {
+    . = ALIGN(32);
+    BYTE(0xFF); . = ALIGN(32);
+  } >FLASH
+
+  /* Remove information from the standard libraries */
+  /DISCARD/ :
+  {
+    libc.a ( * )
+    libm.a ( * )
+    libgcc.a ( * )
+  }
+
+  .ARM.attributes 0 : { *(.ARM.attributes) }
+}

--- a/bl_update/main.c
+++ b/bl_update/main.c
@@ -56,7 +56,16 @@ const struct {
 } app_signature __attribute__((section(".app_signature"))) = {
   .magic1 = APP_SIGNATURE_MAGIC1,
   .magic2 = APP_SIGNATURE_MAGIC2,
+#if BL_TRANSITION
+  /*
+    the transition updater is left behind in the application area once
+    it has run. An impossible length keeps the new bootloader from ever
+    treating it as a bootable application
+   */
+  .fwlen = 0xFFFFFFFF,
+#else
   .fwlen = 0,
+#endif
   .crc1 = 0,
   .crc2 = 0,
   .mcu = AM32_MCU,
@@ -74,6 +83,80 @@ const struct {
 #define PORT_LETTER      0 // dummy
 
 #include <blutil.h>
+
+#if BL_TRANSITION
+/*
+  the transition updater is flashed by a legacy 4k bootloader, which
+  jumps to the application start at 0x08001000. All of our code and the
+  bootloader image we carry must be above the 16k we are about to erase,
+  so the only thing at 0x08001000 is this two word vector table
+ */
+extern uint32_t _estack;
+extern void Reset_Handler(void);
+
+static const uint32_t stub_vector[2] __attribute__((section(".stub_vector"), used)) = {
+  (uint32_t)(uintptr_t)&_estack,
+  (uint32_t)(uintptr_t)Reset_Handler
+};
+
+#define DEVINFO_MAGIC1 0x5925e3da
+#define DEVINFO_MAGIC2 0x4eb863d9
+
+/*
+  find the deviceInfo bytes of the devinfo structure in a bootloader
+  image, or NULL if the image has none
+ */
+static const uint8_t *find_device_info(const uint8_t *base, uint32_t len)
+{
+  const uint32_t magic[2] = { DEVINFO_MAGIC1, DEVINFO_MAGIC2 };
+  for (uint32_t ofs=0; ofs+sizeof(magic)+9 <= len; ofs += 4) {
+    const uint8_t *deviceInfo = &base[ofs+sizeof(magic)];
+    // the deviceInfo always starts with the ESC device type
+    if (memcmp(&base[ofs], magic, sizeof(magic)) == 0 &&
+        memcmp(deviceInfo, "471", 3) == 0) {
+      return deviceInfo;
+    }
+  }
+  return NULL;
+}
+
+/*
+  eeprom address of a bootloader image, from the flash size code in its
+  deviceInfo. Returns 0 if we can't work it out
+ */
+static uint32_t eeprom_address(const uint8_t *base, uint32_t len)
+{
+  const uint8_t *deviceInfo = find_device_info(base, len);
+  if (deviceInfo == NULL) {
+    return 0;
+  }
+  switch (deviceInfo[4]) {
+  case 0x1f: return MCU_FLASH_START + 0x7c00;  // 32k layout
+  case 0x35: return MCU_FLASH_START + 0xf800;  // 64k layout
+  case 0x2b: return MCU_FLASH_START + 0x1f800; // 128k layout
+  }
+  return 0;
+}
+
+/*
+  a CAN bootloader uses the 128k flash layout, so its eeprom is not where
+  a legacy 4k bootloader kept it. Leave that page blank rather than
+  carrying the old settings over: the new bootloader will not boot the
+  application until the ESC is configured again, which is what we want
+  after changing bootloader, and the user sets it up from scratch with
+  the configurator or the DroneCAN GUI tool.
+ */
+static void blank_eeprom(void)
+{
+  const uint32_t addr = eeprom_address(bl_image, sizeof(bl_image));
+  if (addr == 0) {
+    return;
+  }
+  // a zero length write erases the page the address starts and programs
+  // nothing, leaving the eeprom in its erased 0xFF state
+  save_flash_nolib((const uint8_t *)MCU_FLASH_START, 0, addr);
+}
+#endif // BL_TRANSITION
 
 static void delayMicroseconds(uint32_t micros)
 {
@@ -108,6 +191,10 @@ static void flash_bootloader(void)
 
 int main(void)
 {
+#if BL_TRANSITION
+  // we were entered through the stub vector table, point VTOR at the real one
+  SCB->VTOR = MCU_FLASH_START + FIRMWARE_RELATIVE_START;
+#endif
   bl_clock_config();
   bl_timer_init();
 
@@ -128,6 +215,10 @@ int main(void)
       naturally restored on the next boot.
      */
     __disable_irq();
+
+#if BL_TRANSITION
+    blank_eeprom();
+#endif
 
     // do the flash
     flash_bootloader();

--- a/bl_update/make_amj.py
+++ b/bl_update/make_amj.py
@@ -14,6 +14,7 @@ parser = argparse.ArgumentParser(description='make_amj')
 parser.add_argument('hex')
 parser.add_argument('amj')
 parser.add_argument("--type", default="bl_update")
+parser.add_argument("--pin", default=None)
 parser.add_argument("--githash", default="unknown")
 
 args = parser.parse_args()
@@ -39,7 +40,11 @@ if a[0] != 'AM32' or a[2] != 'BL' or a[3] != "UPDATER" or not a[-1].endswith(".h
     print("Bad hex file name")
     sys.exit(1)
 MCU = a[1]
-PIN = a[4]
+# a per-board build is named by its target tag, but the pin recorded here has
+# to be the pin the bootloader really listens on, so that a configurator can
+# check it against the pin the bootloader reports
+TARGET = a[4]
+PIN = args.pin if args.pin else TARGET
 VER = a[-1][:-4]
 
 # anything between the pin and the version is a build tag: a flash size, CAN
@@ -70,6 +75,7 @@ d = {
     "type": args.type,
     "mcuType": MCU,
     "pin": PIN,
+    "target": TARGET,
     "githash": args.githash,
     "version": VER,
     "flashSize": flash_size,

--- a/bl_update/make_amj.py
+++ b/bl_update/make_amj.py
@@ -42,13 +42,26 @@ MCU = a[1]
 PIN = a[4]
 VER = a[-1][:-4]
 
-if len(a) == 6:
-    flash_size = "%uK" % default_flash_sizes[MCU]
-elif len(a) == 7:
-    flash_size = a[-2]
-else:
+# anything between the pin and the version is a build tag: a flash size, CAN
+# for a DroneCAN bootloader, or FROM4K for an updater that a legacy 4k
+# bootloader can flash
+tags = a[5:-1]
+can = "CAN" in tags
+transition = "FROM4K" in tags
+flash_sizes = [t for t in tags if t not in ("CAN", "FROM4K")]
+
+if len(flash_sizes) > 1 or not all(t.endswith("K") for t in flash_sizes):
     print("Bad hex file name2")
     sys.exit(1)
+
+if flash_sizes:
+    flash_size = flash_sizes[0]
+elif can:
+    # CAN builds are always built for the 128k flash layout
+    flash_size = "128K"
+else:
+    flash_size = "%uK" % default_flash_sizes[MCU]
+
 if not MCU in 'E230 F031 F051 F415 F415_128K F421 G071 G071_64K L431 L431_128K G431 V203 A153'.split():
     print(f"Bad MCU {MCU}")
     sys.exit(1)
@@ -60,6 +73,9 @@ d = {
     "githash": args.githash,
     "version": VER,
     "flashSize": flash_size,
+    # a transition updater is flashed by a legacy 4k bootloader, over the top
+    # of the application, rather than by an existing 16k CAN bootloader
+    "transition": transition,
     "hex": base64.b64encode(img).decode('utf-8'),
 }
 

--- a/g431makefile.mk
+++ b/g431makefile.mk
@@ -1,6 +1,10 @@
 MCU := G431
 PART := STM32G431xx
 
+# a legacy 4k G431 bootloader used the 64k flash layout, leaving room for a
+# transition updater between the 16k CAN bootloader and the legacy eeprom
+BL_TRANSITION_$(MCU) := 1
+
 HAL_FOLDER_$(MCU) := $(HAL_FOLDER)/$(call lc,$(MCU))
 
 MCU_$(MCU) := -mcpu=cortex-m4 -mthumb

--- a/l431makefile.mk
+++ b/l431makefile.mk
@@ -1,6 +1,10 @@
 MCU := L431
 PART := STM32L431xx
 
+# a legacy 4k L431 bootloader used the 64k flash layout, leaving room for a
+# transition updater between the 16k CAN bootloader and the legacy eeprom
+BL_TRANSITION_$(MCU) := 1
+
 HAL_FOLDER_$(MCU) := $(HAL_FOLDER)/$(call lc,$(MCU))
 
 MCU_$(MCU) := -mcpu=cortex-m4 -mthumb

--- a/make/parse_targets.py
+++ b/make/parse_targets.py
@@ -6,13 +6,14 @@ Each board is a "#ifdef <BOARDNAME> ... #endif" block containing at least:
     #define FILE_NAME  "<name>"   the MCU is the name token matching a known MCU
                                   family, a trailing _CAN marks a CAN build
     #define TARGET_TAG <tag>      short tag used in the generated target name
+    #define USE_<pin>             the bootloader comms pin, eg USE_PA2
 
 For the ARK_G431_CAN block this produces the build target
 AM32_G431_BOOTLOADER_ARKG4_CAN.
 
 Usage:
-    parse_targets.py builds   -> one line per board: BUILD|TAG|BOARDDEFINE
-                                 e.g. G431_CAN|ARKG4|ARK_G431_CAN
+    parse_targets.py builds   -> one line per board: BUILD|TAG|BOARDDEFINE|PIN
+                                 e.g. G431_CAN|ARKG4|ARK_G431_CAN|PB4
     parse_targets.py mcus     -> unique MCU families used by custom boards
 '''
 
@@ -47,7 +48,8 @@ def parse_boards(path):
                 depth += 1
                 if depth == 1 and s.startswith('#ifdef'):
                     parts = s.split()
-                    cur = {'guard': parts[1], 'file_name': None, 'tag': None}
+                    cur = {'guard': parts[1], 'file_name': None, 'tag': None,
+                           'pin': None}
                 continue
             if s.startswith('#endif'):
                 if depth == 1 and cur is not None:
@@ -70,11 +72,17 @@ def parse_boards(path):
                 m = re.search(r'#define\s+TARGET_TAG\s+(\S+)', line)
                 if m:
                     cur['tag'] = m.group(1)
+            elif '#define' in line and 'USE_P' in line:
+                if is_commented(line, '#define'):
+                    continue
+                m = re.search(r'#define\s+USE_(P[A-Z][0-9]+)\b', line)
+                if m:
+                    cur['pin'] = m.group(1)
     return boards
 
 
 def board_build(board):
-    '''return (build, tag, boarddefine) or None if the MCU is unrecognised'''
+    '''return (build, tag, boarddefine, pin) or None if the MCU is unrecognised'''
     tokens = board['file_name'].split('_')
     mcu = next((t for t in tokens if t in KNOWN_MCUS), None)
     if mcu is None:
@@ -85,7 +93,7 @@ def board_build(board):
     is_can = 'CAN' in tokens
     build = mcu + ('_CAN' if is_can else '')
     tag = board['tag'] if board['tag'] else board['file_name']
-    return (build, tag, board['guard'])
+    return (build, tag, board['guard'], board['pin'] if board['pin'] else tag)
 
 
 def main():
@@ -95,14 +103,14 @@ def main():
     builds = [b for b in (board_build(x) for x in parse_boards(TARGETS_H)) if b]
     if mode == 'mcus':
         mcus = []
-        for build, _, _ in builds:
+        for build, _, _, _ in builds:
             mcu = build.split('_')[0]
             if mcu not in mcus:
                 mcus.append(mcu)
         print(' '.join(mcus))
     else:  # builds
-        for build, tag, define in builds:
-            print('%s|%s|%s' % (build, tag, define))
+        for build, tag, define, pin in builds:
+            print('%s|%s|%s|%s' % (build, tag, define, pin))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This adds bootloader updater firmwares for updating from 4k non-CAN bootloaders to 16k CAN bootloaders.
This difficulty with this type of update is the vector table and initial part of the firmware for the update fw is within the area that will be erased, so we need to leave a gap so that the firmware doesn't erase part of itself 
Tested on a TBS 12S L431 ESC by loading a v16 non-CAN bootloader then loading the obj/AM32_L431_BL_UPDATER_TBS12SL4_CAN_FROM4K_V19.amj via am32.tridgell.net. This updated the ESC to the 16k CAN bootloader and allowed the load of the current AM32 main fw over DroneCAN
